### PR TITLE
Fix: destructuring of proxied object return empty object

### DIFF
--- a/packages/graphql-platform-core/src/graphql-platform/operation/mutation/create-one/value.ts
+++ b/packages/graphql-platform-core/src/graphql-platform/operation/mutation/create-one/value.ts
@@ -20,6 +20,14 @@ const createInputHookProxyHandler: ProxyHandler<CreateOneValue> = {
   ownKeys(create) {
     return [...create.resource.getComponentMap().keys()];
   },
+  getOwnPropertyDescriptor(create, propertyKey) {
+    if (!create.resource.getComponentMap().hasOwnProperty(propertyKey)) {
+      return undefined;
+    }
+    return {
+      enumerable: true,
+    };
+  },
   has(create, propertyKey) {
     return typeof getComponentByPropertyKey(create.resource.getComponentMap(), propertyKey) !== 'undefined';
   },

--- a/packages/graphql-platform-core/src/graphql-platform/operation/mutation/update-one.ts
+++ b/packages/graphql-platform-core/src/graphql-platform/operation/mutation/update-one.ts
@@ -719,10 +719,7 @@ export class UpdateOneOperation extends AbstractOperation<UpdateOneOperationArgs
     const update = new UpdateOneValue(resource, await this.parseDataComponentMap(args.data, context));
 
     if (resource.hasPreHook(ResourceHookKind.PreUpdate)) {
-      const selectionNode =
-          this.resource
-            .getComponentSet()
-            .getSelectionNode(TypeKind.Input);
+      const selectionNode = this.resource.getComponentSet().getSelectionNode(TypeKind.Input);
 
       const toBeUpdatedNodeData = await this.connector.find({
         args: { first: 1, selectionNode, where: nodeId },

--- a/packages/graphql-platform-core/src/graphql-platform/operation/mutation/update-one/value.ts
+++ b/packages/graphql-platform-core/src/graphql-platform/operation/mutation/update-one/value.ts
@@ -27,6 +27,14 @@ const updateInputHookProxyHandler: ProxyHandler<UpdateOneValue> = {
   ownKeys(update) {
     return [...update.resource.getComponentMap().keys()];
   },
+  getOwnPropertyDescriptor(update, propertyKey) {
+    if (!update.resource.getComponentMap().hasOwnProperty(propertyKey)) {
+      return undefined;
+    }
+    return {
+      enumerable: true,
+    };
+  },
   has(update, propertyKey) {
     return typeof getComponentByPropertyKey(update.resource.getComponentMap(), propertyKey) !== 'undefined';
   },

--- a/packages/graphql-platform-core/src/graphql-platform/resource.ts
+++ b/packages/graphql-platform-core/src/graphql-platform/resource.ts
@@ -14,7 +14,14 @@ import {
 import { EventConfigMap, EventEmitter } from '@prismamedia/ts-async-event-emitter';
 import inflector from 'inflection';
 import { Memoize } from 'typescript-memoize';
-import { AnyBaseContext, AnyGraphQLPlatform, BaseContext, Context, CustomContext, NodeSource } from '../graphql-platform';
+import {
+  AnyBaseContext,
+  AnyGraphQLPlatform,
+  BaseContext,
+  Context,
+  CustomContext,
+  NodeSource,
+} from '../graphql-platform';
 import {
   CreateOneOperationArgs,
   CreateOneRawValue,


### PR DESCRIPTION
in order for a property to appear when calling Object.keys(obj), said property must be described as enumerable. Otherwise it is skipped.
Initial bug: console.log({...proxiedObj}) return {} when there is
properties in proxied obj.
full explanation:
https://stackoverflow.com/questions/40352613/why-does-object-keys-and-object-getownpropertynames-produce-different-output